### PR TITLE
Add schema versioning, migration, wipe action, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+# my-weight
+
+A single-page personal weight tracker. The whole app is `index.html` —
+no backend, no build step. Open the file (or serve it statically) and it runs.
+
+## Concept
+
+- User signs in with Google (OAuth via Google Identity Services).
+- Records are stored as a single JSON file in the user's own Google Drive
+  `appDataFolder`. The folder is hidden from the user's normal Drive UI and
+  is scoped per-OAuth-client, so only this app can read or write it.
+- The app developer cannot see user data — there is no server.
+- Users can add records for any date (including years in the past),
+  view a chart, and wipe everything with one click.
+
+## File layout
+
+- `index.html` — the entire app (markup + Tailwind CDN + inline JS).
+- `CLAUDE.md` — this file.
+
+## Tech / dependencies (all CDN, no install)
+
+- Tailwind via `@tailwindcss/browser`.
+- Google Identity Services (`accounts.google.com/gsi/client`) for sign-in.
+- `gapi` client (`apis.google.com/js/api.js`) for Drive API calls.
+- Chart.js 4 + `chartjs-adapter-date-fns` for the weight chart.
+
+CSP allows `https://cdn.jsdelivr.net` for the above plus the Google
+auth/api hosts. If you add another CDN package, it's already covered;
+if you add another origin, update the CSP `<meta>`.
+
+## Drive storage
+
+- Scope: `https://www.googleapis.com/auth/drive.appdata` (app-data only,
+  not full Drive access).
+- File name: `weight_records.json` in `appDataFolder`.
+- The file is found by listing with
+  `q: name='weight_records.json' and 'appDataFolder' in parents`.
+- After login, the entire file is loaded once into memory. Subsequent
+  saves only **upload** the in-memory array (no re-download). The
+  optimistic in-memory push is rolled back if the upload fails.
+
+## Data file format — versioning and migration
+
+This is the part most likely to bite a future change, so read carefully.
+
+### Current schema (version 1)
+
+```json
+{
+  "version": 1,
+  "records": [
+    { "datetime": "2026-05-02T07:14:00.000Z", "weight": 72.5 }
+  ]
+}
+```
+
+- `datetime` is **always UTC ISO 8601** (`new Date(...).toISOString()`).
+  The `datetime-local` input value is converted to UTC at save time;
+  display is converted back via `Intl.DateTimeFormat` at render time.
+- `weight` is a number in kilograms.
+- The schema version constant is `SCHEMA_VERSION` near the top of the
+  inline `<script>`.
+
+### Legacy shapes the app accepts on load
+
+The `migrate(parsed)` function in `index.html` handles three cases:
+
+1. **Bare array** (pre-versioning): `[{...}, {...}]` — wrapped in the
+   v1 envelope.
+2. **Versioned envelope with a different `version` field** — currently
+   only v1 exists, so anything else triggers a rewrite. Add real
+   migration logic when v2 ships.
+3. **Per-record legacy `{date: "YYYY-MM-DD", weight}`** — converted to
+   `{datetime, weight}` by treating the date as local **noon**
+   (`new Date(date + "T12:00:00").toISOString()`). Noon was chosen so
+   that timezone shifts can't push the moment onto an adjacent day.
+
+Records that have neither a valid `datetime` nor a valid `date` are
+**dropped** during migration, and dropping anything sets the
+`migrated` flag.
+
+### Rewrite-on-migration
+
+When `migrate()` reports `migrated: true` and a file already exists,
+`loadRecords()` rewrites the file once with the canonical v1 envelope
+right after the first successful render. This keeps every subsequent
+load on the fast path.
+
+### Adding a new schema version
+
+When you need to change the shape:
+
+1. Bump `SCHEMA_VERSION` to `2`.
+2. In `migrate()`, branch on `parsed.version`:
+   - `1` → run a v1→v2 transform on `parsed.records`, set
+     `migrated = true`.
+   - `2` → use as-is.
+3. Keep the v0 (bare-array) and per-record `{date, weight}` branches
+   intact — old files in the wild may still be on disk.
+4. The rewrite-on-load path will upgrade users transparently the first
+   time they sign in after the change.
+
+### Defensive rendering
+
+Both `renderRecords()` and `renderChart()` filter out records whose
+`datetime` doesn't parse, so a single bad row cannot crash the UI even
+if migration somehow lets one slip through.
+
+## Other implementation notes
+
+- **In-memory cache** (`records`, `fileId`, `recordsLoaded`) is reset on
+  logout. The wipe action also resets it locally and deletes the Drive
+  file via `drive.files.delete`.
+- **History list** is paginated (default 50, options 25/50/100/250/500,
+  persisted in `localStorage` under `my-weight:pageSize`). Sorted
+  newest-first; jumps back to page 1 after a save so the new entry is
+  visible.
+- **Chart** uses Chart.js's `time` scale. Default range is the last 1
+  year. Quick-filter buttons set the range to 7d/30d/6m/1y/5y/all
+  (`all` runs from the oldest record in memory). Manual `from`/`to`
+  date inputs trigger a re-render. Point markers hide above 200 points
+  to keep dense ranges readable.
+- **Status line** under the form shows transient messages (`Načítám...`,
+  `Ukládám...`, errors). The submit button is disabled while a save is
+  in flight; the wipe button is also disabled during its own request.
+- **Quota errors**: the Drive API reason `storageQuotaExceeded` is
+  mapped to a friendly Czech message in `describeDriveError()`. Other
+  errors fall through to the API message.
+
+## Non-goals (deliberate)
+
+- **Sharding / compression.** Even 30 years of daily records is well
+  under 1 MB; the proportional fix when the file gets large is
+  per-year sharding, not gzip. Not needed yet.
+- **Offline mode / sync conflict resolution.** Single-user, single-tab
+  is the assumed usage. Last-writer-wins is fine.
+- **A backend.** The whole point is that the developer cannot see the
+  data; introducing a server would defeat that.
+- **Localization.** UI strings are Czech (`lang="cs"`). If you add
+  another language, factor strings out first.
+
+## Branch convention
+
+Development happens on `claude/review-weight-tracker-app-doTLb` (and
+similarly named feature branches). `main` is the deploy target.

--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
       <button id="logout-btn" class="mt-4 w-full px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition">
         Odhlásit se
       </button>
+      <button id="wipe-btn" class="mt-2 w-full px-4 py-2 bg-red-100 text-red-700 border border-red-300 rounded hover:bg-red-200 transition">
+        Smazat všechna data
+      </button>
     </div>
   </div>
 
@@ -101,6 +104,7 @@
     const CLIENT_ID = '562922982244-e4ci4pc7pj3tche4dat3ra6oam17ath8.apps.googleusercontent.com';
     const SCOPE = 'https://www.googleapis.com/auth/drive.appdata';
     const FILE_NAME = 'weight_records.json';
+    const SCHEMA_VERSION = 1;
 
     let tokenClient;
     let accessToken = null;
@@ -115,6 +119,7 @@
     const appSection = document.getElementById('app-section');
     const weightForm = document.getElementById('weight-form');
     const submitBtn = weightForm.querySelector('button[type="submit"]');
+    const wipeBtn = document.getElementById('wipe-btn');
     const historyList = document.getElementById('history-list');
     const datetimeInput = document.getElementById('datetime');
     const weightInput = document.getElementById('weight');
@@ -272,8 +277,12 @@
         alert('Vyplňte datum/čas a hmotnost.');
         return;
       }
-      const datetime = new Date(local).toISOString();
-      await saveRecord({ datetime, weight });
+      const dt = new Date(local);
+      if (Number.isNaN(dt.getTime())) {
+        alert('Neplatné datum/čas.');
+        return;
+      }
+      await saveRecord({ datetime: dt.toISOString(), weight });
     });
 
     async function findAppDataFile() {
@@ -285,14 +294,83 @@
       return res.result.files[0] || null;
     }
 
+    function migrate(parsed) {
+      let rawRecords;
+      let migrated = false;
+      if (Array.isArray(parsed)) {
+        rawRecords = parsed;
+        migrated = true;
+      } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.records)) {
+        rawRecords = parsed.records;
+        if (parsed.version !== SCHEMA_VERSION) migrated = true;
+      } else {
+        rawRecords = [];
+        migrated = true;
+      }
+
+      const normalized = [];
+      for (const r of rawRecords) {
+        if (!r || typeof r.weight !== 'number') { migrated = true; continue; }
+        if (typeof r.datetime === 'string' && !Number.isNaN(new Date(r.datetime).getTime())) {
+          normalized.push({ datetime: r.datetime, weight: r.weight });
+          continue;
+        }
+        if (typeof r.date === 'string') {
+          const dt = new Date(r.date + 'T12:00:00');
+          if (!Number.isNaN(dt.getTime())) {
+            normalized.push({ datetime: dt.toISOString(), weight: r.weight });
+            migrated = true;
+            continue;
+          }
+        }
+        migrated = true;
+      }
+      return { records: normalized, migrated };
+    }
+
+    async function uploadRecords() {
+      const payload = JSON.stringify({ version: SCHEMA_VERSION, records });
+      if (fileId) {
+        const updateUrl = `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`;
+        const res = await fetch(updateUrl, {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          body: payload
+        });
+        if (!res.ok) throw await res.json();
+      } else {
+        const metadata = { name: FILE_NAME, parents: ['appDataFolder'] };
+        const createUrl = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id';
+        const blob = new Blob([payload], { type: 'application/json' });
+        const form = new FormData();
+        form.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
+        form.append('file', blob);
+        const res = await fetch(createUrl, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${accessToken}` },
+          body: form
+        });
+        if (!res.ok) throw await res.json();
+        const created = await res.json();
+        fileId = created.id;
+      }
+    }
+
     async function loadRecords() {
       setStatus('Načítám...');
       try {
         const file = await findAppDataFile();
+        let needsRewrite = false;
         if (file) {
           fileId = file.id;
           const download = await gapi.client.drive.files.get({ fileId, alt: 'media' });
-          records = JSON.parse(download.body || '[]');
+          const parsed = JSON.parse(download.body || 'null');
+          const result = migrate(parsed);
+          records = result.records;
+          needsRewrite = result.migrated;
         } else {
           fileId = null;
           records = [];
@@ -300,6 +378,10 @@
         recordsLoaded = true;
         renderRecords();
         renderChart();
+        if (needsRewrite && fileId) {
+          setStatus('Aktualizuji formát dat...');
+          await uploadRecords();
+        }
         setStatus('');
       } catch (err) {
         console.error('Error loading records', err);
@@ -312,33 +394,7 @@
       setStatus('Ukládám...');
       records.push(entry);
       try {
-        if (fileId) {
-          const updateUrl = `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`;
-          const res = await fetch(updateUrl, {
-            method: 'PATCH',
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(records)
-          });
-          if (!res.ok) throw await res.json();
-        } else {
-          const metadata = { name: FILE_NAME, parents: ['appDataFolder'] };
-          const createUrl = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id';
-          const blob = new Blob([JSON.stringify(records)], { type: 'application/json' });
-          const form = new FormData();
-          form.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
-          form.append('file', blob);
-          const res = await fetch(createUrl, {
-            method: 'POST',
-            headers: { Authorization: `Bearer ${accessToken}` },
-            body: form
-          });
-          if (!res.ok) throw await res.json();
-          const created = await res.json();
-          fileId = created.id;
-        }
+        await uploadRecords();
         currentPage = 0;
         renderRecords();
         renderChart();
@@ -354,6 +410,32 @@
       }
     }
 
+    async function wipeAllData() {
+      if (!confirm('Opravdu chcete smazat VŠECHNA data o vaší váze? Tuto akci nelze vrátit zpět.')) return;
+      submitBtn.disabled = true;
+      wipeBtn.disabled = true;
+      setStatus('Mažu data...');
+      try {
+        if (fileId) {
+          await gapi.client.drive.files.delete({ fileId });
+        }
+        fileId = null;
+        records = [];
+        currentPage = 0;
+        renderRecords();
+        renderChart();
+        setStatus('Data byla smazána.');
+      } catch (err) {
+        console.error('Error wiping data', err);
+        setStatus('Chyba při mazání: ' + describeDriveError(err), 'error');
+      } finally {
+        submitBtn.disabled = false;
+        wipeBtn.disabled = false;
+      }
+    }
+
+    wipeBtn.addEventListener('click', wipeAllData);
+
     const formatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'short', timeStyle: 'short' });
 
     function renderRecords() {
@@ -366,7 +448,8 @@
         paginationEl.classList.add('hidden');
         return;
       }
-      const sorted = records.slice().sort((a, b) => new Date(b.datetime) - new Date(a.datetime));
+      const valid = records.filter(r => r && typeof r.datetime === 'string' && !Number.isNaN(new Date(r.datetime).getTime()));
+      const sorted = valid.slice().sort((a, b) => new Date(b.datetime) - new Date(a.datetime));
       const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize));
       if (currentPage >= totalPages) currentPage = totalPages - 1;
       if (currentPage < 0) currentPage = 0;
@@ -419,8 +502,8 @@
       const toTs = toVal ? new Date(toVal + 'T23:59:59.999').getTime() : Infinity;
 
       const points = records
-        .map(r => ({ x: new Date(r.datetime).getTime(), y: r.weight }))
-        .filter(p => p.x >= fromTs && p.x <= toTs)
+        .map(r => ({ x: r && typeof r.datetime === 'string' ? new Date(r.datetime).getTime() : NaN, y: r ? r.weight : NaN }))
+        .filter(p => !Number.isNaN(p.x) && !Number.isNaN(p.y) && p.x >= fromTs && p.x <= toTs)
         .sort((a, b) => a.x - b.x);
 
       if (points.length === 0) {


### PR DESCRIPTION
Wraps the Drive payload in a versioned envelope ({version, records}) and adds migrate() to handle bare-array and per-record {date, weight} legacy shapes, with a one-time rewrite on first load. Adds defensive filtering in renderRecords/renderChart and datetime validation at submit so a bad row cannot crash the UI. Adds a "wipe all data" button (confirmed) that deletes the Drive file and resets in-memory cache. Documents concept, storage, schema versions, and migration recipe in CLAUDE.md.